### PR TITLE
Add @primer/css classes to iframe

### DIFF
--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -147,7 +147,7 @@
         />
         
         <iframe 
-          v-bind:src="'http://localhost:3000/embed/0x44c68bc0038635feb4bf7776c24f0c71748fa4bc3a73d3f94115959469da83a1/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48?space=' + this.app.spaces[this.key].skin"
+          v-bind:src="'http://pregov.x5engine.com/embed/0x44c68bc0038635feb4bf7776c24f0c71748fa4bc3a73d3f94115959469da83a1/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48?space=' + this.app.spaces[this.key].skin"
           class="border-top border-bottom border-md rounded-0 rounded-md-2"
           height="250"
           width="100%"

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -148,9 +148,11 @@
         
         <iframe 
           v-bind:src="'http://localhost:3000/embed/0x44c68bc0038635feb4bf7776c24f0c71748fa4bc3a73d3f94115959469da83a1/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48?space=' + this.app.spaces[this.key].skin"
-          height="320"
+          class="border-top border-bottom border-md rounded-0 rounded-md-2"
+          height="250"
           width="100%"
           frameBorder="0"
+          scrolling="no"
         />
         
       </div>


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds @primer/css class to the iframe to more accurately match the other Block components
- Removes scrolling
